### PR TITLE
Make the entries in the `.gitignore` more specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-.idea
-build/cov/
-build/logs/
-composer.lock
+/.idea/
+/build/cov/
+/build/logs/
+/composer.lock
 /vendor/


### PR DESCRIPTION
The listed files/directories should only be ignored in the project root,
not in any random subdirectory.