### PR TITLE
Add an `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# PHP files
+[*.php]
+indent_style = space
+indent_size = 4
+
+# MD files
+[*.md]
+indent_style = space
+indent_size = 4
+
+# XML files
+[*.xml]
+indent_style = space
+indent_size = 4
+
+# YAML files
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /.coveralls.yml export-ignore
+/.editorconfig export-ignore
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.gitignore export-ignore


### PR DESCRIPTION
This helps contributors get the basic formatting options in their IDEs
automatically set right.

(This change does not autoformat any files with these settings, though.)