### PR TITLE
Generate the code coverage data only once per CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,13 +37,19 @@ jobs:
     needs: [php-lint]
     strategy:
       matrix:
-        php-version:
-          - 7.0
-          - 7.1
-          - 7.2
-          - 7.3
-          - 7.4
-          - 8.0
+        include:
+          - php-version: 7.0
+            coverage: none
+          - php-version: 7.1
+            coverage: none
+          - php-version: 7.2
+            coverage: none
+          - php-version: 7.3
+            coverage: none
+          - php-version: 7.4
+            coverage: none
+          - php-version: 8.0
+            coverage: xdebug
 
     steps:
       - name: Checkout
@@ -54,7 +60,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
-          coverage: xdebug
+          coverage: "${{ matrix.coverage }}"
 
       - name: Cache dependencies installed with composer
         uses: actions/cache@v1
@@ -74,6 +80,7 @@ jobs:
         run: ./vendor/bin/phpunit test
 
       - name: Upload coverage results to Coveralls
+        if: "${{ matrix.coverage != 'none' }}"
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
To determine the code coverage of a CI build (and to check whether a
change effects the code coverage), it it enough to generate coverage
once per build.

This also speeds up the build as coverage generation and uploading
is avoided when it is not needed.