### PR TITLE
Make all PHP files strict

### DIFF
--- a/src/ArrayMatrix.php
+++ b/src/ArrayMatrix.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TRegx\DataProvider;
 

--- a/src/CrossDataProviders.php
+++ b/src/CrossDataProviders.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TRegx\DataProvider;
 

--- a/src/DataProviderPairs.php
+++ b/src/DataProviderPairs.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TRegx\DataProvider;
 

--- a/src/DataProviders.php
+++ b/src/DataProviders.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TRegx\DataProvider;
 

--- a/src/DataProvidersBuilder.php
+++ b/src/DataProvidersBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TRegx\DataProvider;
 

--- a/src/DataProvidersEach.php
+++ b/src/DataProvidersEach.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TRegx\DataProvider;
 

--- a/src/DuplicatedValueException.php
+++ b/src/DuplicatedValueException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TRegx\DataProvider;
 

--- a/src/KeyMapper.php
+++ b/src/KeyMapper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TRegx\DataProvider;
 

--- a/src/Type.php
+++ b/src/Type.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TRegx\DataProvider;
 

--- a/test/ArrayMatrixTest.php
+++ b/test/ArrayMatrixTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\TRegx\DataProvider;
 

--- a/test/CrossDataProvidersTest.php
+++ b/test/CrossDataProvidersTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\TRegx\DataProvider;
 

--- a/test/DataProvidersBuilderTest.php
+++ b/test/DataProvidersBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\TRegx\DataProvider;
 

--- a/test/DataProvidersEachTest.php
+++ b/test/DataProvidersEachTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\TRegx\DataProvider;
 

--- a/test/DataProvidersTest.php
+++ b/test/DataProvidersTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\TRegx\DataProvider;
 

--- a/test/KeyMapperTest.php
+++ b/test/KeyMapperTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\TRegx\DataProvider;
 

--- a/test/TypeTest.php
+++ b/test/TypeTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\TRegx\DataProvider;
 

--- a/test/builder/DataProvidersTest.php
+++ b/test/builder/DataProvidersTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\TRegx\DataProvider\builder;
 

--- a/test/pairs/DataProvidersTest.php
+++ b/test/pairs/DataProvidersTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\TRegx\DataProvider\pairs;
 


### PR DESCRIPTION
This make sure that the required types are indeed provided.