### PR TITLE
Git-ignore the PHPUnit cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea/
+/.phpunit.result.cache
 /build/cov/
 /build/logs/
 /composer.lock


### PR DESCRIPTION
Newer versions of PHPUnit create this file, and we want to keep it
away from versioning.