### PR TITLE
Add Composer scripts for code sniffing and autofixing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,6 @@
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.gitignore export-ignore
+/phpcs.xml export-ignore
 /phpunit.xml export-ignore
 /tests/ export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea/
+/.php_cs.cache
 /.phpunit.result.cache
 /build/cov/
 /build/logs/

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,20 @@
   },
   "require-dev": {
     "phpunit/phpunit": "*",
-    "php-coveralls/php-coveralls": "^2.4"
+    "php-coveralls/php-coveralls": "^2.4",
+    "squizlabs/php_codesniffer": "^3.6"
+  },
+  "scripts": {
+    "ci": [
+      "@ci:static"
+    ],
+    "ci:static": [
+      "@phpcs"
+    ],
+    "fix": [
+      "@phpcbf"
+    ],
+    "phpcs": "phpcs src test",
+    "phpcbf": "phpcbf src test"
   }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="phpList Coding Standard">
+    <description>
+        This standard requires PHP_CodeSniffer >= 3.6.0.
+    </description>
+
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+
+    <!-- PHP -->
+    <rule ref="Generic.PHP.RequireStrictTypes"/>
+</ruleset>


### PR DESCRIPTION
There now are the following new Composer scripts:

- `ci`: run all CI-related Composer scripts
- `ci:static` run the static code analysis
- `phpcs` run PHP_CodeSniffer
- `fix` fix the autofixable PHP code warnings
- `phpcbf` fix the autofixable PHP_CodeSniffer warnings

For starters, we have a sniff that checks that all files are in
PHP strict mode. (The CI builds do not run this check as the files
are not strict yet at this point.)

The PHP_CodeSniffer autofixer cannot make files strict, though
(as this is a non-autofixable code sniff). It will be able to
autofix other things we'll add later, though.