### PR TITLE
Drop the `archive` section from the `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,5 @@
   "require-dev": {
     "phpunit/phpunit": "*",
     "php-coveralls/php-coveralls": "^2.4"
-  },
-  "archive": {
-    "exclude": [
-      "/test/**",
-      "/test"
-    ]
   }
 }


### PR DESCRIPTION
We keep files from packaging for Packagist via `.gitattributes` now.

Fixes #22