### PR TITLE
Add static type analysis with PHPStan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,7 @@
 /.github/ export-ignore
 /.gitignore export-ignore
 /phpcs.xml export-ignore
+/phpstan-baseline.neon export-ignore
+/phpstan.neon.dist export-ignore
 /phpunit.xml export-ignore
 /tests/ export-ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,3 +114,39 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./vendor/bin/php-coveralls --coverage_clover=build/logs/clover.xml -v
+
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-20.04
+    needs: [ php-lint ]
+    strategy:
+      matrix:
+        include:
+          - php-version: 7.4
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+
+      - name: Cache dependencies installed with composer
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/composer
+          key: php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            php${{ matrix.php-version }}-composer-
+
+      - name: Install Composer dependencies
+        run: |
+          composer install --no-progress;
+          composer update --with-dependencies --no-progress;
+          composer show;
+
+      - name: Run PHPStan
+        run: composer phpstan

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /build/cov/
 /build/logs/
 /composer.lock
+/phpstan.neon
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,24 @@
   "require-dev": {
     "phpunit/phpunit": "*",
     "php-coveralls/php-coveralls": "^2.4",
-    "squizlabs/php_codesniffer": "^3.6"
+    "squizlabs/php_codesniffer": "^3.6",
+    "phpstan/phpstan": "^1.2.0",
+    "phpstan/phpstan-phpunit": "^1.0.0",
+    "phpstan/extension-installer": "^1.1.0"
   },
   "scripts": {
-    "phpcs": "phpcs"
+    "phpcs": "phpcs",
+    "phpstan": "phpstan",
+    "phpstan:baseline": "phpstan --generate-baseline"
   },
   "scripts-descriptions": {
-    "phpcs": "Checks the coding style of the PHP files."
+    "phpcs": "Checks the coding style of the PHP files.",
+    "phpstan": "Checks the types with PHPStan.",
+    "phpstan:baseline": "Updates the PHPStan baseline file to match the code."
+  },
+  "config": {
+    "allow-plugins": {
+      "phpstan/extension-installer": true
+    }
   }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,282 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\ArrayMatrix\\:\\:cross\\(\\) has parameter \\$dataProviders with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ArrayMatrix.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\ArrayMatrix\\:\\:cross\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ArrayMatrix.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\ArrayMatrix\\:\\:crossTwo\\(\\) has parameter \\$array1 with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ArrayMatrix.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\ArrayMatrix\\:\\:crossTwo\\(\\) has parameter \\$array2 with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ArrayMatrix.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\ArrayMatrix\\:\\:crossTwo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ArrayMatrix.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\ArrayMatrix\\:\\:keyName\\(\\) has parameter \\$new with no type specified\\.$#"
+			count: 1
+			path: src/ArrayMatrix.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\ArrayMatrix\\:\\:keyName\\(\\) has parameter \\$previous with no type specified\\.$#"
+			count: 1
+			path: src/ArrayMatrix.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\ArrayMatrix\\:\\:quoteKeys\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ArrayMatrix.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\ArrayMatrix\\:\\:quoteKeys\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ArrayMatrix.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:arrayScalarUnique\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:arrayScalarUnique\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:formatPairKey\\(\\) has parameter \\$left with no type specified\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:formatPairKey\\(\\) has parameter \\$right with no type specified\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:getDistinctPairs\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:getDistinctPairs\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:getDuplicates\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:getDuplicates\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:getMixedPairs\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:getMixedPairs\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:getPairs\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:getPairs\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:isComparable\\(\\) has parameter \\$input with no type specified\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviderPairs\\:\\:validateDuplicates\\(\\) has parameter \\$values with no type specified\\.$#"
+			count: 1
+			path: src/DataProviderPairs.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviders\\:\\:__construct\\(\\) has parameter \\$mapper with no type specified\\.$#"
+			count: 1
+			path: src/DataProviders.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviders\\:\\:distinctPairs\\(\\) has parameter \\$values with no type specified\\.$#"
+			count: 1
+			path: src/DataProviders.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviders\\:\\:distinctPairs\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviders.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviders\\:\\:each\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviders.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviders\\:\\:each\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviders.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviders\\:\\:eachNamed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/DataProviders.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviders\\:\\:eachNamed\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviders.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviders\\:\\:mapEntries\\(\\) has parameter \\$entries with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviders.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviders\\:\\:mapEntries\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviders.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviders\\:\\:pairs\\(\\) has parameter \\$values with no type specified\\.$#"
+			count: 1
+			path: src/DataProviders.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviders\\:\\:pairs\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviders.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProviders\\:\\:validateDataProviders\\(\\) has parameter \\$entries with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviders.php
+
+		-
+			message: "#^Property TRegx\\\\DataProvider\\\\DataProviders\\:\\:\\$dataProviders type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProviders.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProvidersBuilder\\:\\:__construct\\(\\) has parameter \\$dataProviders with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProvidersBuilder.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProvidersBuilder\\:\\:__construct\\(\\) has parameter \\$mapper with no type specified\\.$#"
+			count: 1
+			path: src/DataProvidersBuilder.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProvidersBuilder\\:\\:addJoinedSection\\(\\) has parameter \\$sections with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProvidersBuilder.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProvidersBuilder\\:\\:addSection\\(\\) has parameter \\$singleDataProvider with no type specified\\.$#"
+			count: 1
+			path: src/DataProvidersBuilder.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProvidersBuilder\\:\\:build\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProvidersBuilder.php
+
+		-
+			message: "#^Property TRegx\\\\DataProvider\\\\DataProvidersBuilder\\:\\:\\$dataProviders type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProvidersBuilder.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProvidersEach\\:\\:each\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProvidersEach.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProvidersEach\\:\\:each\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProvidersEach.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProvidersEach\\:\\:eachNamed\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProvidersEach.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProvidersEach\\:\\:eachNamed\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProvidersEach.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProvidersEach\\:\\:getDuplicates\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/DataProvidersEach.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProvidersEach\\:\\:getDuplicates\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProvidersEach.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DataProvidersEach\\:\\:validateDuplicates\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DataProvidersEach.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\DuplicatedValueException\\:\\:__construct\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/DuplicatedValueException.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\KeyMapper\\:\\:map\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/KeyMapper.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\KeyMapper\\:\\:map\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/KeyMapper.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\KeyMapper\\:\\:mapperArgument\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/KeyMapper.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\KeyMapper\\:\\:mapperArgument\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: src/KeyMapper.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\Type\\:\\:asPrettyString\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Type.php
+
+		-
+			message: "#^Method TRegx\\\\DataProvider\\\\Type\\:\\:asString\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Type.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,16 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+  parallel:
+    # Don't be overly greedy on machines with more CPU's to be a good neighbor especially on CI
+    maximumNumberOfProcesses: 5
+
+  level: 6
+
+  scanDirectories:
+    - %currentWorkingDirectory%/src/
+    - %currentWorkingDirectory%/test/
+  paths:
+    - %currentWorkingDirectory%/src/
+    - %currentWorkingDirectory%/test/


### PR DESCRIPTION
Add Composer scripts for checking the code with PHPStan (while using
a baseline) and for updating the baseline.

When we fix PHPStan-reported issues (or update the PHPStan configuration),
we can update the baseline bit by bit until all issues are fixed.