### PR TITLE
Stop using `get_resources()` without arguments

### DIFF
--- a/test/TypeTest.php
+++ b/test/TypeTest.php
@@ -52,9 +52,11 @@ class TypeTest extends TestCase
         ];
     }
 
+    /**
+     * @return resource
+     */
     private static function getResource()
     {
-        $resources = get_resources();
-        return reset($resources);
+        return opendir(__DIR__);
     }
 }


### PR DESCRIPTION
In PHP < 8, `get_resources` always need to be used with an
argument.

Also add type annotations and method visibility.