### PR TITLE
Ignore incorrect types where we test for incorrect types

### DIFF
--- a/test/DataProvidersTest.php
+++ b/test/DataProvidersTest.php
@@ -49,6 +49,7 @@ class DataProvidersTest extends TestCase
         $this->expectExceptionMessage('Arguments composed of an associative array');
 
         // given
+        // @phpstan-ignore-next-line as we are explicitly testing whether violating the contract will raise an exception
         DataProviders::cross([['A'], ['value' => 'value']]);
     }
 
@@ -62,6 +63,7 @@ class DataProvidersTest extends TestCase
         $this->expectExceptionMessage("Argument list is supposed to be an array, 'string' given");
 
         // given
+        // @phpstan-ignore-next-line as we are explicitly testing whether violating the contract will raise an exception
         DataProviders::cross([['A'], 'not an array']);
     }
 


### PR DESCRIPTION
PHPStan should not complain about cases where we intentionally
violate the contract in order to test that this will rais an
exception.