### PR TITLE
Fix the PHP_CodeSniffer-related Composer commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "squizlabs/php_codesniffer": "^3.6"
   },
   "scripts": {
-    "phpcs": "phpcs"
+    "phpcbf": "phpcbf src test",
+    "phpcs": "phpcs src test"
   }
 }


### PR DESCRIPTION
- add the paths to sniff/fix
- add the removed Composer script `phpcbf` for autofixing