### PR TITLE
Add a description for the `phpcs` Composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,8 @@
   },
   "scripts": {
     "phpcs": "phpcs"
+  },
+  "scripts-descriptions": {
+    "phpcs": "Checks the coding style of the PHP files."
   }
 }


### PR DESCRIPTION
The description will be displayed if `composer` is run without
any arguments.