### PR TITLE
Add the missing visibility to a test data provider

### DIFF
--- a/test/TypeTest.php
+++ b/test/TypeTest.php
@@ -27,7 +27,10 @@ class TypeTest extends TestCase
         $this->assertEquals($expectedString, $string);
     }
 
-    function typesMap(): array
+    /**
+     * @return array<string, array<{0: mixed, 1: string}>
+     */
+    public function typesMap(): array
     {
         return [
             'null' => [null, 'null'],


### PR DESCRIPTION
This fixes a PSR-12 violation.

Also add a PHPDoc return type annotation.