### PR TITLE
Fix the return type annotations

### DIFF
--- a/src/CrossDataProviders.php
+++ b/src/CrossDataProviders.php
@@ -9,7 +9,7 @@ class CrossDataProviders
     /**
      * @param array<string|int, array<int, mixed>> ...$dataProviders
      *
-     * @return array<string, array<int, mixed>>
+     * @return array<string|int, array<int, mixed>>
      */
     public static function cross(array ...$dataProviders): array
     {

--- a/src/DataProviders.php
+++ b/src/DataProviders.php
@@ -26,7 +26,7 @@ class DataProviders
     }
 
     /**
-     * @return array<string, array<int, mixed>>
+     * @return array<string|int, array<int, mixed>>
      */
     public function create(): array
     {
@@ -48,7 +48,7 @@ class DataProviders
     /**
      * @param array<string|int, array<int, mixed>> ...$dataProviders
      *
-     * @return array<string, array<int, mixed>>
+     * @return array<string|int, array<int, mixed>>
      */
     public static function cross(array ...$dataProviders): array
     {


### PR DESCRIPTION
If only once data provider is passed for crossing, and if it has
numeric keys, the returned array will also have numeric keys,
not string keys.

The type annotations needs to reflect this.